### PR TITLE
Fixes #155

### DIFF
--- a/app/views/proposals_dashboard/index.html.erb
+++ b/app/views/proposals_dashboard/index.html.erb
@@ -30,6 +30,13 @@
                         class: 'menu-entry',
                         data: { confirm: t('images.actions.destroy.confirm') } %>
           <% end %>
+        
+          <% unless proposal.retired? %>
+            <%= link_to t('.retire'),
+                        retire_form_proposal_path(proposal),
+                        class: 'menu-entry',
+                        target: '_blank' %>
+          <% end %>
 
           <%= link_to t('.publish'), publish_proposal_dashboard_index_path(proposal), method: :patch, class: 'menu-entry' if can?(:publish, proposal) %>
         <% end %>

--- a/app/views/users/_proposal.html.erb
+++ b/app/views/users/_proposal.html.erb
@@ -11,24 +11,15 @@
       <span class="label alert"><%= t('users.proposals.retired') %></span>
     </td>
 
-  <% elsif author?(proposal) %>
-
-    <td>
-      <%= link_to t("users.proposals.send_notification"),
-                  new_proposal_notification_path(proposal_id: proposal.id),
-                  class: 'button hollow expanded' %>
-    </td>
-
+  <% elsif can?(:dashboard, proposal) %>
     <td>
       <% if proposal.retired? %>
         <span class="label alert"><%= t('users.proposals.retired') %></span>
       <% else %>
-        <%= link_to t('users.proposals.retire'),
-                    retire_form_proposal_path(proposal),
-                    class: 'button hollow alert expanded' %>
+        <%= link_to t('proposals.show.dashboard_proposal_link'), 
+                    proposal_dashboard_index_path(proposal), class: 'button hollow expanded' %>
       <% end %>
     </td>
-
   <% else %>
 
     <td class="text-center" colspan="2">

--- a/app/views/users/_proposals.html.erb
+++ b/app/views/users/_proposals.html.erb
@@ -1,7 +1,7 @@
 <table class="margin-top">
   <thead>
     <th scope="col"><%= t("users.show.proposals") %></th>
-    <th scope="col" colspan="2"><%= t("users.show.actions") %></th>
+    <th scope="col"><%= t("users.show.actions") %></th>
   </thead>
   <tbody>
     <% @proposals.each do |proposal| %>

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -483,6 +483,7 @@ en:
       publish: Publish
       edit_proposal_link: Edit
       send_notification: Send notification
+      retire: Retire
   polls:
     all: "All"
     no_dates: "no date assigned"
@@ -778,7 +779,6 @@ en:
       delete_alert: "Are you sure you want to delete your investment project? This action can't be undone"
     proposals:
       send_notification: "Send notification"
-      retire: "Retire"
       retired: "Retired proposal"
       see: "See proposal"
   votes:

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -483,6 +483,7 @@ es:
       publish: Publicar
       edit_proposal_link: Editar propuesta
       send_notification: Enviar notificación
+      retire: Retirar
   polls:
     all: "Todas"
     no_dates: "sin fecha asignada"
@@ -777,7 +778,6 @@ es:
       delete_alert: "¿Estás seguro de que deseas borrar tu proyecto de gasto? Esta acción no se puede deshacer"
     proposals:
       send_notification: "Enviar notificación"
-      retire: "Retirar"
       retired: "Propuesta retirada"
       see: "Ver propuesta"
   votes:


### PR DESCRIPTION
References
==========
Fixes #155 in Medialab repository

Objectives
==========
Replace the buttons 
* Send notification
* Retire
in My Activity view by a link to the proposal dashboard.

Retire should be available in the dashboard

Visual Changes (if any)
=======================
Retire is available in the dashboard.
Proposals in My Activity have a link to the proposal dashboard
